### PR TITLE
Updated the contribution registration to use the fully qualified contributionId

### DIFF
--- a/calendarServices.html
+++ b/calendarServices.html
@@ -19,6 +19,21 @@
             "Calendar/EventSources/VSOCapacityEventSource",
             "Calendar/EventSources/VSOIterationEventSource"
         ], function (FreeFormEventsSource, VSOCapacityEventSource, VSOIterationEventSource) {
+
+            // Register the eventSource contributions using the fully qualified contributionId
+            VSS.register("ms-devlabs.team-calendar.freeForm", function (context) {
+                return new FreeFormEventsSource.FreeFormEventsSource();
+            });
+            VSS.register("ms-devlabs.team-calendar.daysOff", function (context) {
+                return new VSOCapacityEventSource.VSOCapacityEventSource();
+            });
+            VSS.register("ms-devlabs.team-calendar.iterations", function (context) {
+                return new VSOIterationEventSource.VSOIterationEventSource();
+            });
+
+            // Deprecated form of contribution registration using the short Id for back-compat.
+            // DO NOT register this form any longer, use the fully qualified contributionId
+            //  unless you have previous shipped dependencies on the short Id's
             VSS.register("freeForm", function (context) {
                 return new FreeFormEventsSource.FreeFormEventsSource();
             });
@@ -28,6 +43,7 @@
             VSS.register("iterations", function (context) {
                 return new VSOIterationEventSource.VSOIterationEventSource();
             });
+
             VSS.notifyLoadSucceeded();
         });
     </script>


### PR DESCRIPTION
Updated the contribution registration to use the fully qualified contributionId.
Keep support for the short Id's in place to support old consumers.