### PR TITLE
Fix 'Promise not defined' errors in IE

### DIFF
--- a/src/Calendar/Dialogs.ts
+++ b/src/Calendar/Dialogs.ts
@@ -1,3 +1,4 @@
+import "es6-promise/auto";
 import * as Calendar_Contracts from "./Contracts";
 import * as Context from "VSS/Context";
 import * as Controls from "VSS/Controls";


### PR DESCRIPTION
add es6-promise polyfill to Dialogs.ts