### PR TITLE
Update node-sass package so package will compile.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "css-loader": "~0.28.7",
     "extract-text-webpack-plugin": "~3.0.2",
     "ncp": "~2.0.0",
-    "node-sass": "~4.5.3",
+    "node-sass": "^4.11.0",
     "postcss-loader": "~2.0.8",
     "rimraf": "~2.5.4",
     "sass-loader": "~6.0.6",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     {
       "name": "Serkan Inci",
       "email": "serkani@microsoft.com"
+    },
+    {
+      "name:": "Nick George",
+      "email": "ngeorge@valorem.com"
     }
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vso-team-calendar",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Track events important to your team, view and manage days off, quickly see when sprints start and end, and more.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This node-sass package that is currently being used is out of date and the .node file it uses is no longer available on GitHub. After upgrading, it now compiles for people wishing to contribute and has no affect on the code running.