### PR TITLE
Fix calendar events not loading on initial render

### DIFF
--- a/src/FreeFormEventSource.ts
+++ b/src/FreeFormEventSource.ts
@@ -85,7 +85,7 @@ export class FreeFormEventsSource {
         const calendarEnd = new Date(arg.end);
         calendarEnd.setDate(arg.end.getDate() - 1);
 
-        this.fetchEvents(calendarStart, calendarEnd).then(() => {
+        return this.fetchEvents(calendarStart, calendarEnd).then(() => {
             const inputs: EventInput[] = [];
             const catagoryMap: { [id: string]: IEventCategory } = {};
             Object.keys(this.eventMap).forEach(id => {
@@ -148,6 +148,9 @@ export class FreeFormEventsSource {
                 }
                 return catagory;
             });
+        }).catch((error: any) => {
+            console.error("[FreeFormEventSource] Error fetching events:", error);
+            failureCallback({ message: error.message || "Failed to load custom events" });
         });
     };
 

--- a/src/VSOCapacityEventSource.ts
+++ b/src/VSOCapacityEventSource.ts
@@ -120,7 +120,7 @@ export class VSOCapacityEventSource {
 
         this.groupedEventMap = {};
 
-        this.fetchIterations().then(iterations => {
+        return this.fetchIterations().then(iterations => {
             if (!iterations) {
                 iterations = [];
             }
@@ -220,6 +220,9 @@ export class VSOCapacityEventSource {
                     return catagory;
                 });
             });
+        }).catch((error: any) => {
+            console.error("[VSOCapacityEventSource] Error fetching events:", error);
+            failureCallback({ message: error.message || "Failed to load iteration and days off data" });
         });
     };
 


### PR DESCRIPTION
Events were not appearing when the calendar first loaded because the getEvents() methods in both event sources were not returning the Promise chains. FullCalendar requires event source functions to either call callbacks synchronously or return a Promise.

Changes:
- Return Promise from FreeFormEventsSource.getEvents()
- Return Promise from VSOCapacityEventSource.getEvents()
- Add error handling to call failureCallback on data loading failures
- Add console logging for better debugging

This fixes the issue where users had to navigate forward/back a month to see events appear, as the cache would be populated by then from the previous incomplete async call.