### PR TITLE
Fix member avatars not loading in calendar

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -6,7 +6,7 @@
   "name": "Team Calendar",
   "description": "Track events important to your team, view and manage days off, quickly see when sprints start and end, and more.",
   "public": true,
-  "categories": ["Plan and Track"],
+  "categories": ["Azure Boards"],
   "targets": [
     {
       "id": "Microsoft.VisualStudio.Services.Cloud"
@@ -16,7 +16,7 @@
       "version": "[18.0,)"
     }
   ],
-  "scopes": ["vso.work_write"],
+  "scopes": ["vso.work_write", "vso.graph"],
   "icons": {
     "default": "static/v2-images/calendar-logo.png"
   },

--- a/src/AvatarIcon.tsx
+++ b/src/AvatarIcon.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+import { getAvatarDataUri, getInitialsAvatar } from "./AvatarService";
+
+interface IAvatarIconProps {
+    // Graph subject descriptor used to fetch the avatar; undefined falls back to initials.
+    descriptor?: string;
+    // Unique id used to cache the resolved avatar (member id or team id).
+    identityId?: string;
+    displayName: string;
+    className?: string;
+}
+
+// Renders a member/team avatar, showing an initials placeholder until the real avatar resolves.
+export const AvatarIcon: React.FC<IAvatarIconProps> = props => {
+    const { descriptor, identityId, displayName, className } = props;
+    const [src, setSrc] = React.useState<string>(() => getInitialsAvatar(displayName));
+
+    React.useEffect(() => {
+        let cancelled = false;
+        const cacheKey = identityId || descriptor || displayName;
+        setSrc(getInitialsAvatar(displayName));
+        getAvatarDataUri(descriptor, cacheKey, displayName).then(resolved => {
+            if (!cancelled) {
+                setSrc(resolved);
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [descriptor, identityId, displayName]);
+
+    return <img alt="" className={className} src={src} />;
+};

--- a/src/AvatarService.ts
+++ b/src/AvatarService.ts
@@ -1,0 +1,106 @@
+import { getClient } from "azure-devops-extension-api";
+import { GraphRestClient } from "azure-devops-extension-api/Graph";
+import { Avatar, AvatarSize } from "azure-devops-extension-api/Profile";
+
+import { generateColor } from "./Color";
+
+// Resolves Azure DevOps member avatars via the Graph REST client and returns them as data URIs,
+// with a locally generated initials avatar as the fallback.
+
+const avatarCache = new Map<string, Promise<string>>();
+const initialsCache = new Map<string, string>();
+
+let graphClient: GraphRestClient | undefined;
+
+function getGraphClient(): GraphRestClient {
+    if (!graphClient) {
+        graphClient = getClient(GraphRestClient);
+    }
+    return graphClient;
+}
+
+function avatarToDataUri(avatar: Avatar): string | null {
+    const raw: any = avatar ? avatar.value : undefined;
+    if (!raw) {
+        return null;
+    }
+
+    let base64: string;
+    if (typeof raw === "string") {
+        base64 = raw;
+    } else {
+        // getAvatar can return the image as a byte array; encode it to base64.
+        let binary = "";
+        for (let i = 0; i < raw.length; i++) {
+            binary += String.fromCharCode(raw[i] & 0xff);
+        }
+        base64 = btoa(binary);
+    }
+
+    return "data:image/png;base64," + base64;
+}
+
+function escapeXml(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+}
+
+function getInitials(displayName: string): string {
+    const parts = (displayName || "").trim().split(/\s+/).filter(part => part.length > 0);
+    if (parts.length === 0) {
+        return "?";
+    }
+    if (parts.length === 1) {
+        return parts[0].charAt(0).toUpperCase();
+    }
+    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}
+
+function buildInitialsSvg(displayName: string): string {
+    const initials = escapeXml(getInitials(displayName));
+    const color = generateColor(displayName || "?");
+    const svg =
+        '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">' +
+        '<circle cx="16" cy="16" r="16" fill="' + color + '"/>' +
+        '<text x="16" y="21" font-family="Segoe UI, Arial, sans-serif" font-size="13" font-weight="600" ' +
+        'fill="#ffffff" text-anchor="middle">' + initials + "</text>" +
+        "</svg>";
+    return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svg);
+}
+
+// Locally generated, initials-based avatar as an SVG data URI, used as a placeholder and fallback.
+export function getInitialsAvatar(displayName: string): string {
+    const key = displayName || "";
+    const existing = initialsCache.get(key);
+    if (existing) {
+        return existing;
+    }
+    const uri = buildInitialsSvg(key);
+    initialsCache.set(key, uri);
+    return uri;
+}
+
+// Resolves a member avatar to a data URI, falling back to an initials avatar when no descriptor is
+// available or the lookup fails. Results are cached per identity.
+export function getAvatarDataUri(descriptor: string | undefined, identityId: string, displayName: string): Promise<string> {
+    if (!descriptor) {
+        return Promise.resolve(getInitialsAvatar(displayName));
+    }
+
+    const cached = avatarCache.get(identityId);
+    if (cached) {
+        return cached;
+    }
+
+    const promise = getGraphClient()
+        .getAvatar(descriptor, AvatarSize.Medium)
+        .then(avatar => avatarToDataUri(avatar) || getInitialsAvatar(displayName))
+        .catch(() => getInitialsAvatar(displayName));
+
+    avatarCache.set(identityId, promise);
+    return promise;
+}

--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -36,6 +36,7 @@ import { localeData } from "moment";
 
 import { AddEditDaysOffDialog } from "./AddEditDaysOffDialog";
 import { AddEditEventDialog } from "./AddEditEventDialog";
+import { getAvatarDataUri, getInitialsAvatar } from "./AvatarService";
 import { generateColor } from "./Color";
 import { ICalendarEvent } from "./Contracts";
 import { FreeFormId, FreeFormEventsSource } from "./FreeFormEventSource";
@@ -700,13 +701,21 @@ class ExtensionContent extends React.Component {
                 capacityEvent.icons.slice(0, maxIconsToShow).forEach(element => {
                     if (element.src) {
                         var img: HTMLImageElement = document.createElement("img");
-                        img.src = element.src;
+                        const member = element.linkedEvent.member;
+                        const displayName = member ? member.displayName : element.linkedEvent.title;
+                        // Show initials until the real avatar resolves.
+                        img.src = getInitialsAvatar(displayName);
                         img.className = "event-icon";
                         img.title = element.linkedEvent.title;
                         img.onclick = () => {
                             this.eventToEdit = element.linkedEvent;
                             this.openDialog.value = Dialogs.NewDaysOffDialog;
                         };
+                        if (member) {
+                            getAvatarDataUri(member.descriptor, member.id, displayName).then(src => {
+                                img.src = src;
+                            });
+                        }
                         var content = arg.el.querySelector(".fc-content");
                         if (content) {
                             content.appendChild(img);

--- a/src/Contracts.d.ts
+++ b/src/Contracts.d.ts
@@ -64,6 +64,11 @@ export interface ICalendarMember {
      * Unique ID for the member
      */
     id: string;
+
+    /**
+     * Graph subject descriptor, used to fetch the member's avatar via the Graph API
+     */
+    descriptor?: string;
 }
 
 /**

--- a/src/SummaryComponent.tsx
+++ b/src/SummaryComponent.tsx
@@ -8,6 +8,7 @@ import { Observer } from "azure-devops-ui/Observer";
 import { Surface, SurfaceBackground } from "azure-devops-ui/Surface";
 
 import { IEventCategory } from "./Contracts";
+import { AvatarIcon } from "./AvatarIcon";
 import { FreeFormEventsSource } from "./FreeFormEventSource";
 import { formatDateLocalized } from "./TimeLib";
 import { VSOCapacityEventSource } from "./VSOCapacityEventSource";
@@ -230,7 +231,14 @@ export class SummaryComponent extends React.Component<ISummaryComponentProps, IS
                     style={{ cursor: "pointer", padding: "2px 8px 2px 8px", alignItems: "center" }}
                     onClick={handleClick}
                 >
-                    {item.imageUrl && <img alt="" className="category-icon" src={item.imageUrl} />}
+                    {item.imageUrl && (
+                        <AvatarIcon
+                            className="category-icon"
+                            descriptor={item.linkedEvent && item.linkedEvent.member ? item.linkedEvent.member.descriptor : undefined}
+                            identityId={item.linkedEvent && item.linkedEvent.member ? item.linkedEvent.member.id : undefined}
+                            displayName={item.title}
+                        />
+                    )}
                     {!item.imageUrl && displayColor && <div className="category-color" style={{ backgroundColor: displayColor }} />}
                     <div className="flex-column h-scroll-hidden catagory-data" style={{ flex: 1 }}>
                         <div className="category-titletext">{item.title}</div>

--- a/src/VSOCapacityEventSource.ts
+++ b/src/VSOCapacityEventSource.ts
@@ -336,26 +336,6 @@ export class VSOCapacityEventSource {
         }
     };
 
-    private async buildTeamImageUrl(id: string): Promise<string> {
-        if (!this.locationService) {
-            throw new Error("Location service is required for building team image URLs. Ensure the location service is properly initialized before calling this method.");
-        }
-
-        try {
-            // Use location service to get the proper resource area URL for GraphProfile
-            const graphResourceLocation = await this.locationService.getResourceAreaLocation("79134C72-4A58-4B42-976C-04E7115F32BF");
-            if (graphResourceLocation) {
-                return graphResourceLocation + "_apis/GraphProfile/MemberAvatars/" + id;
-            }
-        } catch (error) {
-            console.warn("GraphProfile resource area not available, trying service location fallback", error);
-        }
-
-        // Fallback to service location with legacy endpoint
-        const serviceLocation = await this.locationService.getServiceLocation();
-        return serviceLocation + "_api/_common/IdentityImage?id=" + id;
-    }
-
     private fetchCapacities = (iterationId: string): Promise<TeamMemberCapacityIdentityRef[]> => {
         // fetch capacities only if not in cache
         if (this.capacityMap[iterationId]) {
@@ -417,7 +397,8 @@ export class VSOCapacityEventSource {
 
                     const icon: IEventIcon = {
                         linkedEvent: event,
-                        src: capacity.teamMember.imageUrl || await this.buildTeamImageUrl(capacity.teamMember.id)
+                        // Presence flag that this icon has an avatar; the image is resolved from member.descriptor.
+                        src: capacity.teamMember.id
                     };
 
                     // Track this day off range in the category map (once per range, not per day)
@@ -439,7 +420,7 @@ export class VSOCapacityEventSource {
                                 } else {
                                     capacityCatagoryMap[capacity.teamMember.id] = {
                                         eventCount: 1,
-                                        imageUrl: capacity.teamMember.imageUrl || await this.buildTeamImageUrl(capacity.teamMember.id),
+                                        imageUrl: capacity.teamMember.id,
                                         subTitle: formatDateLocalized(start) + " - " + formatDateLocalized(end),
                                         title: capacity.teamMember.displayName,
                                         linkedEvent: event,
@@ -480,7 +461,6 @@ export class VSOCapacityEventSource {
         if (teamDaysOff && teamDaysOff.daysOff) {
             this.teamDayOffMap[iterationId] = teamDaysOff;
             for (const daysOffRange of teamDaysOff.daysOff) {
-                const teamImage = await this.buildTeamImageUrl(this.teamContext.teamId);
                 const start = shiftToLocal(daysOffRange.start);
                 const end = shiftToLocal(daysOffRange.end);
 
@@ -498,7 +478,7 @@ export class VSOCapacityEventSource {
 
                 const icon: IEventIcon = {
                     linkedEvent: event,
-                    src: teamImage
+                    src: this.teamContext.teamId
                 };
 
                 // Track this day off range in the category map (once per range, not per day)
@@ -520,7 +500,7 @@ export class VSOCapacityEventSource {
                             } else {
                                 capacityCatagoryMap[this.teamContext.team] = {
                                     eventCount: 1,
-                                    imageUrl: teamImage,
+                                    imageUrl: this.teamContext.teamId,
                                     subTitle: formatDateLocalized(start) + " - " + formatDateLocalized(end),
                                     title: this.teamContext.team,
                                     linkedEvent: event,


### PR DESCRIPTION
Fixes #594

Member and team avatars stopped loading. Loading the avatar image URL directly no longer works because the request is unauthenticated and gets redirected to sign-in, so the browser refuses the response.

This switches avatar loading to the Graph REST client's getAvatar, which returns the image bytes over the standard authenticated API the extension already uses for work data. The bytes are turned into a data URI and set as the image source. When an avatar can't be resolved, it falls back to an initials avatar coloured from the display name.

Changes:
- Add AvatarService to fetch avatars via getAvatar and generate initials fallbacks
- Add AvatarIcon component and use it in the summary panel
- Carry the member subject descriptor through to the calendar and summary
- Add the vso.graph scope required by getAvatar
- Remove the old MemberAvatars URL builder

**Note: this adds the vso.graph scope, so existing installs will need to re-authorise on upgrade.**

-----

AI assisted but I have manually tested it.

Before:

<img width="346" height="125" alt="image" src="https://github.com/user-attachments/assets/1655f26e-d28d-4020-88b3-a56ee7b99dfd" />



After:

<img width="349" height="124" alt="image" src="https://github.com/user-attachments/assets/6932235e-def3-4406-9042-94e428049a9c" />

